### PR TITLE
Protect calls to GeoIP calls with our mutex

### DIFF
--- a/geoip.go
+++ b/geoip.go
@@ -184,7 +184,11 @@ func (gi *GeoIP) GetRecord(ip string) *GeoIPRecord {
 
 	cip := C.CString(ip)
 	defer C.free(unsafe.Pointer(cip))
+
+	gi.mu.Lock()
 	record := C.GeoIP_record_by_addr(gi.db, cip)
+	gi.mu.Unlock()
+
 	if record == nil {
 		return nil
 	}


### PR DESCRIPTION
Tracing through the call stack we have a few calls that end up calling _GeoIP_seek_record deep in the callstack which clobbers our global netmask.  So, even though we don't query for the netmask, to prevent some other goroutine from getting the wrong answer we need to protect these calls too.
