### PR TITLE
Add GetTimeZone func

### DIFF
--- a/geoip.go
+++ b/geoip.go
@@ -213,7 +213,12 @@ func (gi *GeoIP) GetRecord(ip string) *GeoIPRecord {
 // Returns the Time Zone name from the tz database
 // e.g. "America/New_York"
 func GetTimeZone(country_code, region string) string {
-	return C.GoString(C.GeoIP_time_zone_by_country_and_region(C.CString(country_code), C.CString(region)))
+	cc := C.CString(country_code)
+	defer C.free(unsafe.Pointer(cc))
+	cr := C.CString(region)
+	defer C.free(unsafe.Pointer(cr))
+
+	return C.GoString(C.GeoIP_time_zone_by_country_and_region(cc, cr))
 }
 
 // Returns the country code and region code for an IP address. Requires


### PR DESCRIPTION
Let's wrap this function in the CAPI:

``` c
const char * GeoIP_time_zone_by_country_and_region(const char *country_code, const char *region_code);
```
