### PR TITLE
Support other GeoIPOptions flags when Opening db file

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,5 +1,6 @@
 package geoip
 
+// GeoIPDBTypes enum in GeoIP.h
 const (
 	GEOIP_COUNTRY_EDITION            = 1
 	GEOIP_REGION_EDITION_REV0        = 7
@@ -32,4 +33,13 @@ const (
 	GEOIP_CITY_EDITION_REV0_V6       = 31
 	GEOIP_NETSPEED_EDITION_REV1      = 32
 	GEOIP_NETSPEED_EDITION_REV1_V6   = 33
+)
+
+// GeoIPOptions enum in GeoIP.h
+const (
+	GEOIP_STANDARD     = 0
+	GEOIP_MEMORY_CACHE = 1
+	GEOIP_CHECK_CACHE  = 2
+	GEOIP_INDEX_CACHE  = 4
+	GEOIP_MMAP_CACHE   = 8
 )

--- a/geoip_test.go
+++ b/geoip_test.go
@@ -37,7 +37,7 @@ func (s *GeoIPSuite) TestOpenType(c *C) {
 	// SetCustomDirectory("/Users/ask/go/src/geoip/db")
 
 	// Open Country database
-	gi, err := OpenType(GEOIP_COUNTRY_EDITION)
+	gi, err := OpenType(GEOIP_COUNTRY_EDITION, GEOIP_MEMORY_CACHE)
 	c.Check(err, IsNil)
 	c.Assert(gi, NotNil)
 	country, _ := gi.GetCountry("207.171.7.51")


### PR DESCRIPTION
`Open()` and `OpenType()` currently use GEOIP_MEMORY_CACHE as the open flag. Other flags should be supported.

