### PR TITLE
Implement `go vet` fix.

### DIFF
--- a/ex/geoip-demo.go
+++ b/ex/geoip-demo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/abh/geoip"
 )
 
@@ -54,7 +55,7 @@ func main() {
 
 }
 
-func test4(g geoip.GeoIP, ip string) {
+func test4(g *geoip.GeoIP, ip string) {
 	test(func(s string) (string, int) { return g.GetCountry(s) }, ip)
 }
 


### PR DESCRIPTION
`go vet` complains with the following: `github.com/abh/geoip/ex/geoip-demo.go:57: test4 passes Lock by value: github.com/abh/geoip.GeoIP contains sync.Mutex`